### PR TITLE
v04.0 — 2026 optimization, debloat, safety net & full reversibility

### DIFF
--- a/OPTY.bat
+++ b/OPTY.bat
@@ -1,18 +1,40 @@
 :::: OPTY by @YannD-Deltagon ::::
 
 @echo off
-set current_version=02.4
+set current_version=04.0
 set GitHubRawLink=https://raw.githubusercontent.com/YannD-Deltagon/OPTY/master/resources/
 set GitHubLatestLink=https://github.com/YannD-Deltagon/OPTY/releases/latest/download/
+
+:: ---- User / paths configuration (edit here if your username or layout differs) ----
+set "USERHOME=C:\Users\compt"
+set "WSL_DOCKER_VHDX=%USERHOME%\AppData\Local\Docker\wsl\disk\docker_data.vhdx"
+set "WSL_SEARCH1=%USERHOME%\AppData\Local\Packages"
+set "WSL_SEARCH2=%USERHOME%\AppData\Local\wsl"
+set "DOCKER_EXE=C:\Program Files\Docker\Docker\Docker Desktop.exe"
+
+:: ---- ANSI / VT colors for live colored console output (CMD on Windows 10/11) ----
+reg add "HKCU\Console" /v VirtualTerminalLevel /t REG_DWORD /d 1 /f >nul 2>&1
+for /f "delims=" %%E in ('echo prompt $E^| cmd') do set "ESC=%%E"
+set "cR=%ESC%[0m"
+set "cT=%ESC%[1;96m"
+set "cOK=%ESC%[1;92m"
+set "cWarn=%ESC%[1;93m"
+set "cErr=%ESC%[1;91m"
+set "cInfo=%ESC%[90m"
+set "cStep=%ESC%[1;95m"
+set "cVal=%ESC%[1;97m"
 
 cd /d "%~dp0"
 for /f "skip=15 delims=" %%F in ('dir /b /a-d /o:-d "%~dp0logs_*.txt"') do (
     del "%~dp0%%F"
 )
 
-set current_time="%time:~0,5%"
-set current_time="%current_time::=-%"
-set logs="%~dp0\logs_%date%_%current_time%.txt"
+set "current_date=%date:/=-%"
+set "current_date=%current_date: =_%"
+set "current_time=%time:~0,5%"
+set "current_time=%current_time::=-%"
+set "current_time=%current_time: =0%"
+set logs="%~dp0logs_%current_date%_%current_time%.txt"
 
 echo.                                                           >> %logs%
 echo ====================== :START SCRIPT ====================== >> %logs%
@@ -51,6 +73,8 @@ if not "%~dp0" == "C:\OPTY_by-YannD\" (
     del "%~dp0OPTY.bat"
     exit
 )
+
+call :sysinfo
 
 :ping_github
 echo.                                                           >> %logs%
@@ -122,6 +146,7 @@ echo   Current version: v%current_version%
 echo   Latest version: v%latest_version%                      
 echo.                                                  
 echo.                                                  
+set "choice="
 set /p choice=Do you want to update ? Y (Yes) - N (No)
 echo %date% %time% : User choice for update = "%choice%"       >> %logs%
 if /i "%choice%"=="Y" goto update_found_and_accepted
@@ -205,15 +230,15 @@ echo.
 echo   0. Exit                                                         
 echo.                                                  
 echo.                                                  
+set "choice="
 set /p choice= Enter action:
 echo %date% %time% : Menu.bat-menuadmin "%choice%"                    >> %logs%
-if "%choice%"=="1" goto mopti
-if "%choice%"=="2" goto mreenable
-if "%choice%"=="3" goto mregprofil
+if "%choice%"=="1" (call :restore_point & goto mopti)
+if "%choice%"=="2" (call :restore_point & goto mreenable)
+if "%choice%"=="3" (call :restore_point & goto mregprofil)
 if "%choice%"=="9" goto Clean_Opty_Curl
 if "%choice%"=="0" goto end
 if "%choice%"=="." goto update_opty
-if "%choice%"=="-" goto mupdate_perso
 color 0C
 echo This is not a valid action                                      
 echo %date% %time% : Invalid menu choice                             >> %logs%
@@ -222,6 +247,9 @@ goto menu
 
 
 :mopti
+call :get_free_mb "%SystemDrive%"
+set "FREE_BEFORE=%FREE_MB%"
+>>%logs% echo %date% %time% : Free space %SystemDrive% before = %FREE_BEFORE% MB
 echo.                                                           >> %logs%
 echo ====================== :MOPTI ======================           >> %logs%
 echo.                                                           >> %logs%
@@ -260,6 +288,7 @@ echo.
 echo   0. Menu                                                         
 echo.                                                  
 echo.                                                  
+set "choice="
 set /p choice= Enter action:
 echo %date% %time% : Opti-mopti "%choice%"                            >> %logs%
 if /i "%choice%"=="1" set autoclean=0 & set autoshutdownreboot=5 & echo %date% %time% : Variables - autoclean=%autoclean%, autoshutdownreboot=%autoshutdownreboot% >> %logs% & goto mdisenable
@@ -311,6 +340,7 @@ echo   2. Next
 echo   0. Menu                                                          
 echo.                                                  
 echo.                                                  
+set "choice="
 set /p choice= Enter action:
 echo %date% %time% : Opti-mdisenable "%choice%"                         >> %logs%
 if /i "%choice%"=="-ani" echo %date% %time% : Action - Disable animations (MenuAnimate=0) >> %logs% & echo  -ani & reg add "HKEY_CURRENT_USER\Control Panel\Desktop" /v "MenuAnimate" /t REG_SZ /d "0" /f & pause & goto mdisenable
@@ -345,6 +375,8 @@ echo.                                                           >> %logs%
 echo ====================== :STARTREADY ======================     >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :startready label                      >> %logs%
+wsl --shutdown
+echo %date% %time% : Executed wsl --shutdown (free WSL/Docker resources)   >> %logs%
 net stop bits
 echo %date% %time% : Stopped service: bits                            >> %logs%
 net stop wuauserv
@@ -372,6 +404,7 @@ echo.                                                           >> %logs%
 echo %date% %time% : Entered :mnetdns label                          >> %logs%
 cls
 echo Do you want to flush DNS and reset IP - IPCONFIG and NETSH?
+set "choice="
 set /p choice= 1 (Yes) - 2 (No)
 echo %date% %time% : Opti-mnetdns "%choice%"                              >> %logs%
 if /i "%choice%"=="1" goto netdns
@@ -387,14 +420,23 @@ echo.                                                           >> %logs%
 echo ====================== :NETDNS ======================       >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :netdns label                           >> %logs%
+call :L "%cStep%" "NETWORK - DNS flush + TCP tuning (Winsock/IP reset is manual-only)..."
 ipconfig /flushdns
 echo %date% %time% : Executed ipconfig /flushdns                      >> %logs%
+if "%autoclean%"=="2" goto netdns_tcp
 netsh int ip reset
 echo %date% %time% : Executed netsh int ip reset                      >> %logs%
 netsh winsock reset
 echo %date% %time% : Executed netsh winsock reset                     >> %logs%
 netsh winsock reset proxy
 echo %date% %time% : Executed netsh winsock reset proxy               >> %logs%
+:netdns_tcp
+:: --- TCP/IP performance tuning ---
+call :L "%cInfo%" "Re-asserting good TCP defaults (autotuning normal / rss on / heuristics off)"
+netsh int tcp set global autotuninglevel=normal
+netsh int tcp set heuristics disabled
+netsh int tcp set global rss=enabled
+echo %date% %time% : Re-applied TCP good defaults (autotuning/rss/heuristics, ECN left default)  >> %logs%
 if /i %autoclean% == 2 goto dism
 timeout /t 5
 
@@ -406,6 +448,7 @@ echo.                                                           >> %logs%
 echo %date% %time% : Entered :mdism label                            >> %logs%
 cls
 echo Do you want to DISM the Windows image and correct problems?
+set "choice="
 set /p choice= 1 (Yes) - 2 (No)
 echo %date% %time% : Opti-mdism "%choice%"                              >> %logs%
 if /i "%choice%"=="1" goto dism
@@ -421,11 +464,15 @@ echo.                                                           >> %logs%
 echo ====================== :DISM ======================        >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :dism label                               >> %logs%
+call :L "%cStep%" "DISM - repairing the Windows component store..."
+dism /Online /Cleanup-Image /AnalyzeComponentStore
+>>%logs% echo %date% %time% : DISM AnalyzeComponentStore exit=%errorlevel%
 dism /Online /Cleanup-image /ScanHealth
 echo %date% %time% : Executed DISM /ScanHealth                         >> %logs%
 dism /Online /Cleanup-image /CheckHealth
 echo %date% %time% : Executed DISM /CheckHealth                        >> %logs%
 dism /Online /Cleanup-image /RestoreHealth
+>>%logs% echo %date% %time% : DISM RestoreHealth exit=%errorlevel%
 echo %date% %time% : Executed DISM /RestoreHealth                      >> %logs%
 dism /Online /Cleanup-image /StartComponentCleanup /ResetBase
 echo %date% %time% : Executed DISM /StartComponentCleanup /ResetBase    >> %logs%
@@ -440,6 +487,7 @@ echo.                                                           >> %logs%
 echo %date% %time% : Entered :msfc label                               >> %logs%
 cls
 echo Do you want to run SFC to verify system file integrity and fix problems?
+set "choice="
 set /p choice= 1 (Yes) - 2 (No)
 echo %date% %time% : Opti-msfc "%choice%"                              >> %logs%
 if /i "%choice%"=="1" goto sfc
@@ -455,7 +503,9 @@ echo.                                                           >> %logs%
 echo ====================== :SFC ======================         >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :sfc label                                >> %logs%
+call :L "%cStep%" "SFC - verifying system file integrity..."
 sfc /scannow
+>>%logs% echo %date% %time% : SFC exit=%errorlevel%
 echo %date% %time% : Executed SFC /scannow                             >> %logs%
 if /i %autoclean% == 2 goto wupdate
 timeout /t 5
@@ -468,6 +518,7 @@ echo.                                                           >> %logs%
 echo %date% %time% : Entered :mwupdate label                          >> %logs%
 cls
 echo Do you want to update Windows - USOCLIENT?
+set "choice="
 set /p choice= 1 (Yes) - 2 (No)
 echo %date% %time% : Opti-mwupdate "%choice%"                          >> %logs%
 if /i "%choice%"=="1" goto wupdate
@@ -483,12 +534,9 @@ echo.                                                           >> %logs%
 echo ====================== :WUPDATE ======================      >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :wupdate label                           >> %logs%
-usoclient StartScan
-echo %date% %time% : Executed usoclient StartScan                      >> %logs%
-usoclient RefreshSettings
-echo %date% %time% : Executed usoclient RefreshSettings                >> %logs%
-usoclient StartInstall
-echo %date% %time% : Executed usoclient StartInstall                   >> %logs%
+call :L "%cStep%" "WINDOWS UPDATE - scanning and installing updates..."
+usoclient scaninstallwait
+echo %date% %time% : Executed usoclient scaninstallwait (scan+download+install) >> %logs%
 if /i %autoclean% == 1 goto delete
 if /i %autoclean% == 2 goto delete
 timeout /t 5
@@ -501,6 +549,7 @@ echo.                                                           >> %logs%
 echo %date% %time% : Entered :mclean label                            >> %logs%
 cls
 echo Execute clean disk - CLEANMGR?
+set "choice="
 set /p choice= 1 (Yes) - 2 (No)
 echo %date% %time% : Opti-mclean "%choice%"                            >> %logs%
 if /i "%choice%"=="1" goto clean
@@ -517,11 +566,93 @@ echo ====================== :CLEAN ======================       >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :clean label                            >> %logs%
 echo Cleanmgr...                                                 
+if /i "%autoclean%"=="2" (cleanmgr /verylowdisk & goto clean_wsl)
 cleanmgr /sageset:65535
 echo %date% %time% : Executed cleanmgr /sageset:65535              >> %logs%
 pause
 cleanmgr /sagerun:65535
 echo %date% %time% : Executed cleanmgr /sagerun:65535              >> %logs%
+timeout /t 5
+
+
+:clean_wsl
+echo.                                                           >> %logs%
+echo ====================== :CLEAN_WSL ====================== >> %logs%
+echo.                                                           >> %logs%
+echo %date% %time% : Entered :clean_wsl label                     >> %logs%
+echo.
+call :L "%cStep%" "WSL and Docker - compacting virtual disks, this can take several minutes..."
+echo  Compacting WSL / Docker virtual disks...
+echo  ^(Docker Desktop and WSL are closed first - this can take several minutes^)
+echo.
+
+:: 1) Ask Docker Desktop to quit cleanly, then wait until it has fully stopped
+echo %date% %time% : Asking Docker Desktop to quit (clean)         >> %logs%
+set "WSL_UTF8=1"
+if exist "%DOCKER_EXE%" (
+    echo  Asking Docker Desktop to quit cleanly...
+    "%DOCKER_EXE%" -quit
+) else (
+    echo  Docker Desktop.exe not found, relying on wsl --shutdown only.
+    echo %date% %time% : Docker Desktop.exe not found                 >> %logs%
+)
+
+:: Wait (max 120s) until the docker-desktop WSL distro AND backend have stopped
+set /a wsl_wait=0
+:clean_wsl_waitloop
+set "DOCKER_UP="
+wsl --list --running 2>nul | findstr /i "docker-desktop" >nul 2>&1 && set "DOCKER_UP=1"
+tasklist /fi "imagename eq com.docker.backend.exe" 2>nul | findstr /i "com.docker.backend.exe" >nul 2>&1 && set "DOCKER_UP=1"
+if not defined DOCKER_UP goto clean_wsl_stopped
+if %wsl_wait% GEQ 120 goto clean_wsl_forcekill
+echo   Docker is shutting down cleanly... (%wsl_wait%s / 120s max)
+timeout /t 3 /nobreak >nul
+set /a wsl_wait+=3
+goto clean_wsl_waitloop
+
+:clean_wsl_forcekill
+echo  Clean shutdown timed out, forcing Docker processes to stop...
+echo %date% %time% : Docker clean-stop timeout, forcing kill          >> %logs%
+taskkill /f /im "Docker Desktop.exe" /t        >nul 2>&1
+taskkill /f /im "com.docker.backend.exe" /t    >nul 2>&1
+taskkill /f /im "com.docker.build.exe" /t      >nul 2>&1
+taskkill /f /im "com.docker.cli.exe" /t        >nul 2>&1
+taskkill /f /im "vpnkit.exe" /t                >nul 2>&1
+
+:clean_wsl_stopped
+echo  Docker stopped. Shutting down WSL to release the disks...
+echo %date% %time% : Docker stopped, shutting down WSL                 >> %logs%
+wsl --shutdown >nul 2>&1
+timeout /t 5 /nobreak >nul
+
+:: 2) Build the list of .vhdx to compact (Docker data disk + WSL distro ext4.vhdx)
+del /f /q "%TEMP%\opty_vhdx.lst" >nul 2>&1
+if exist "%WSL_DOCKER_VHDX%" >>"%TEMP%\opty_vhdx.lst" echo %WSL_DOCKER_VHDX%
+for /f "delims=" %%V in ('dir /b /s "%WSL_SEARCH1%\ext4.vhdx" 2^>nul') do >>"%TEMP%\opty_vhdx.lst" echo %%V
+for /f "delims=" %%V in ('dir /b /s "%WSL_SEARCH2%\ext4.vhdx" 2^>nul') do >>"%TEMP%\opty_vhdx.lst" echo %%V
+
+:: 3) Compact each disk via diskpart: select / attach readonly / compact / detach
+if not exist "%TEMP%\opty_vhdx.lst" (
+    echo  No WSL / Docker virtual disk found, skipping.
+    echo %date% %time% : No vhdx found to compact                  >> %logs%
+) else (
+    for /f "usebackq delims=" %%F in ("%TEMP%\opty_vhdx.lst") do (
+        echo  -^> %%F
+        echo %date% %time% : Compacting "%%F"                      >> %logs%
+        >"%TEMP%\opty_diskpart.txt"  echo select vdisk file="%%F"
+        >>"%TEMP%\opty_diskpart.txt" echo attach vdisk readonly
+        >>"%TEMP%\opty_diskpart.txt" echo compact vdisk
+        >>"%TEMP%\opty_diskpart.txt" echo detach vdisk
+        >>"%TEMP%\opty_diskpart.txt" echo exit
+        diskpart /s "%TEMP%\opty_diskpart.txt"
+        echo %date% %time% : Compaction done "%%F"                 >> %logs%
+    )
+    del /f /q "%TEMP%\opty_diskpart.txt" >nul 2>&1
+    del /f /q "%TEMP%\opty_vhdx.lst"     >nul 2>&1
+)
+echo %date% %time% : WSL/Docker vhdx compaction done               >> %logs%
+
+if /i %autoclean% == 2 goto defrag
 timeout /t 5
 
 
@@ -532,6 +663,7 @@ echo.                                                           >> %logs%
 echo %date% %time% : Entered :mdelete label                          >> %logs%
 cls
 echo Do you want to delete temporary files - DEL?
+set "choice="
 set /p choice= 1 (Yes) - 2 (No)
 echo %date% %time% : Opti-mdelete "%choice%"                            >> %logs%
 if /i "%choice%"=="1" goto delete
@@ -548,6 +680,12 @@ echo ====================== :DELETE ======================       >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :delete label                           >> %logs%
 
+call :L "%cStep%" "CLEANUP - deleting temp files, caches, logs and dumps..."
+call :L "%cInfo%" "Enabling Storage Sense (native automatic maintenance)"
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\StorageSense" /v "AllowStorageSenseGlobal" /t REG_DWORD /d 1 /f >nul
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\StorageSense\Parameters\StoragePolicy" /v "01" /t REG_DWORD /d 1 /f >nul
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\StorageSense\Parameters\StoragePolicy" /v "04" /t REG_DWORD /d 1 /f >nul
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\StorageSense\Parameters\StoragePolicy" /v "2048" /t REG_DWORD /d 30 /f >nul
 :: --- Windows Update download cache ---
 echo %date% %time% : Stopping wuauserv service                       >> %logs%
 net stop wuauserv >nul 2>&1
@@ -562,8 +700,7 @@ del /F /S /Q "%ProgramData%\Microsoft\Windows\DeliveryOptimization\Cache\*"
 
 :: --- Temp (system + all users Local\Temp as in your model) ---
 echo %date% %time% : Deleting Windows Temp folder                     >> %logs%
-del /S /F /Q "%WINDIR%\Temp"
-rd /S /Q "%WINDIR%\Temp" 2>nul
+del /S /F /Q "%WINDIR%\Temp\*"
 
 echo %date% %time% : Deleting user Temp files                         >> %logs%
 setlocal
@@ -593,9 +730,9 @@ del /S /F /Q "%LOCALAPPDATA%\Microsoft\DirectX Shader Cache\*"
 
 :: --- DaVinci Resolve caches (user scope only) ---
 echo %date% %time% : Deleting DaVinci Resolve media cache (user)        >> %logs%
-del /F /S /Q "C:\Users\compt\Documents\DaVinci\*"
+del /F /S /Q "%USERHOME%\Documents\DaVinci\*"
 echo %date% %time% : Deleting DaVinci AppData Roaming CacheClip >> %logs%
-del /F /S /Q "C:\Users\compt\AppData\Roaming\Blackmagic Design\DaVinci Resolve\Support\CacheClip\*"
+del /F /S /Q "%USERHOME%\AppData\Roaming\Blackmagic Design\DaVinci Resolve\Support\CacheClip\*"
 
 :: --- Dumps (facultatif mais sans impact sur réglages) ---
 echo %date% %time% : Deleting MiniDump files                             >> %logs%
@@ -615,10 +752,95 @@ for %%D in (C D E F) do if exist "%%D:\" (
   rd /S /Q "%%D:\$Recycle.Bin" 2>nul
 )
 
+:: --- Thumbnail & icon cache (rebuilt automatically; locked files are skipped) ---
+echo %date% %time% : Deleting thumbnail/icon cache                  >> %logs%
+del /F /S /Q "%USERHOME%\AppData\Local\Microsoft\Windows\Explorer\thumbcache_*.db" 2>nul
+del /F /S /Q "%USERHOME%\AppData\Local\Microsoft\Windows\Explorer\iconcache_*.db" 2>nul
+
+:: --- Windows Error Reporting reports + crash dumps ---
+echo %date% %time% : Deleting WER reports and crash dumps           >> %logs%
+del /F /S /Q "%ProgramData%\Microsoft\Windows\WER\*" 2>nul
+del /F /S /Q "%USERHOME%\AppData\Local\Microsoft\Windows\WER\*" 2>nul
+del /F /S /Q "%USERHOME%\AppData\Local\CrashDumps\*" 2>nul
+
+:: --- Old servicing / setup logs (CBS, Panther) ---
+echo %date% %time% : Deleting CBS and Panther logs                  >> %logs%
+del /F /S /Q "%WINDIR%\Logs\CBS\*" 2>nul
+del /F /S /Q "%WINDIR%\Panther\*" 2>nul
+
+:: --- Legacy IE/Edge system web cache (INetCache) ---
+echo %date% %time% : Deleting INetCache                             >> %logs%
+del /F /S /Q "%USERHOME%\AppData\Local\Microsoft\Windows\INetCache\*" 2>nul
+
+:: --- GPU driver extraction leftovers (NOT the installed drivers) ---
+echo %date% %time% : Deleting driver extraction folders            >> %logs%
+rd /S /Q "C:\NVIDIA" 2>nul
+rd /S /Q "C:\AMD"    2>nul
+rd /S /Q "C:\Intel"  2>nul
+
+:: --- Browser + Store (closes apps): FULL mode only, skipped in Auto-lite ---
+if not "%autoclean%"=="2" goto delete_skip_apps
+echo %date% %time% : Closing Edge/Chrome and clearing their caches  >> %logs%
+taskkill /f /im msedge.exe  >nul 2>&1
+taskkill /f /im chrome.exe  >nul 2>&1
+del /F /S /Q "%USERHOME%\AppData\Local\Microsoft\Edge\User Data\Default\Cache\*"        2>nul
+del /F /S /Q "%USERHOME%\AppData\Local\Microsoft\Edge\User Data\Default\Code Cache\*"   2>nul
+del /F /S /Q "%USERHOME%\AppData\Local\Microsoft\Edge\User Data\Default\GPUCache\*"     2>nul
+del /F /S /Q "%USERHOME%\AppData\Local\Google\Chrome\User Data\Default\Cache\*"         2>nul
+del /F /S /Q "%USERHOME%\AppData\Local\Google\Chrome\User Data\Default\Code Cache\*"    2>nul
+del /F /S /Q "%USERHOME%\AppData\Local\Google\Chrome\User Data\Default\GPUCache\*"      2>nul
+
+:: --- Microsoft Store download cache (wsreset) ---
+echo %date% %time% : Resetting Microsoft Store cache               >> %logs%
+start "" wsreset.exe
+timeout /t 15 /nobreak >nul
+taskkill /f /im "WinStore.App.exe" >nul 2>&1
+:delete_skip_apps
+
+:: --- Windows.old (removes rollback): FULL mode only ---
+if not "%autoclean%"=="2" goto delete_skip_winold
+if exist "%SystemDrive%\Windows.old" (
+    echo %date% %time% : Removing Windows.old previous installation  >> %logs%
+    takeown /F "%SystemDrive%\Windows.old" /R /A /D Y               >nul 2>&1
+    icacls "%SystemDrive%\Windows.old" /grant administrators:F /T /C >nul 2>&1
+    rd /S /Q "%SystemDrive%\Windows.old" 2>nul
+)
+:delete_skip_winold
+
+call :L "%cInfo%" "Cleaning app caches (Spotify / Teams / Discord)"
+del /F /S /Q "%USERHOME%\AppData\Local\Spotify\Storage\*"             2>nul
+del /F /S /Q "%USERHOME%\AppData\Local\Spotify\Data\*"                2>nul
+del /F /S /Q "%USERHOME%\AppData\Roaming\Spotify\Storage\*"           2>nul
+del /F /S /Q "%USERHOME%\AppData\Roaming\discord\Cache\*"             2>nul
+del /F /S /Q "%USERHOME%\AppData\Roaming\discord\Code Cache\*"        2>nul
+del /F /S /Q "%USERHOME%\AppData\Roaming\discord\GPUCache\*"          2>nul
+del /F /S /Q "%USERHOME%\AppData\Roaming\Microsoft\Teams\Cache\*"     2>nul
+del /F /S /Q "%USERHOME%\AppData\Roaming\Microsoft\Teams\GPUCache\*"  2>nul
+del /F /S /Q "%USERHOME%\AppData\Local\Packages\MSTeams_8wekyb3d8bbwe\LocalCache\*" 2>nul
+
+call :L "%cInfo%" "Clearing font cache (Prefetch left intact - it speeds up app launches)"
+net stop FontCache >nul 2>&1
+del /F /S /Q "%WINDIR%\ServiceProfiles\LocalService\AppData\Local\FontCache\*" 2>nul
+del /F /Q "%WINDIR%\System32\FNTCACHE.DAT" 2>nul
+net start FontCache >nul 2>&1
+
+if not "%autoclean%"=="2" goto delete_skip_vss
+call :L "%cInfo%" "Trimming old restore points (keeping the most recent)"
+set "SHCOUNT=0"
+for /f %%c in ('vssadmin list shadows /for=%SystemDrive% 2^>nul ^| find /c "HarddiskVolumeShadowCopy"') do set "SHCOUNT=%%c"
+echo %date% %time% : Shadow copies on %SystemDrive% = %SHCOUNT%      >> %logs%
+:vss_trim_loop
+if %SHCOUNT% LEQ 1 goto vss_trim_done
+vssadmin delete shadows /for=%SystemDrive% /oldest /quiet >nul 2>&1
+set /a SHCOUNT-=1
+goto vss_trim_loop
+:vss_trim_done
+:delete_skip_vss
+
 echo %date% %time% : :delete done                                        >> %logs%
 
 if /i %autoclean% == 1 goto mshutdownreboot
-if /i %autoclean% == 2 goto defrag
+if /i %autoclean% == 2 goto clean
 timeout /t 5
 
 
@@ -629,6 +851,7 @@ echo.                                                           >> %logs%
 echo %date% %time% : Entered :mdefrag label                          >> %logs%
 cls
 echo Do you want to defragment HDD or optimize SSD - DEFRAG?
+set "choice="
 set /p choice= 1 (Yes) - 2 (No)
 echo %date% %time% : Opti-mdefrag "%choice%"                            >> %logs%
 if /i "%choice%"=="1" goto defrag
@@ -644,7 +867,9 @@ echo.                                                           >> %logs%
 echo ====================== :DEFRAG ======================       >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :defrag.label                           >> %logs%
+call :L "%cStep%" "DEFRAG - optimizing all volumes..."
 defrag /C /O /U /V /H
+>>%logs% echo %date% %time% : DEFRAG exit=%errorlevel%
 echo %date% %time% : Executed defrag /C /O /U /V /H                 >> %logs%
 if /i %autoclean% == 2 goto endready
 timeout /t 5
@@ -656,11 +881,16 @@ echo ====================== :MCHKDSK ======================       >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :mchkdsk label                          >> %logs%
 cls
-echo Do you want to check drive integrity and fix issues - CHKDSK?
-set /p choice= 1 (Yes) - 2 (No)
+echo Check drive integrity - CHKDSK?
+echo   1. Online scan (SSD-safe, no reboot)
+echo   2. Full /f /r (HDD only - locks the volume, schedules a reboot)
+echo   3. Skip
+set "choice="
+set /p choice= Enter action:
 echo %date% %time% : Opti-mchkdsk "%choice%"                            >> %logs%
 if /i "%choice%"=="1" goto chkdsk
-if /i "%choice%"=="2" goto mshutdownreboot
+if /i "%choice%"=="2" goto chkdsk_full
+if /i "%choice%"=="3" goto mshutdownreboot
 if /i "%choice%"=="0" goto menu
 echo This is not a valid action                                      
 echo %date% %time% : Invalid option in :mchkdsk                          >> %logs%
@@ -672,9 +902,23 @@ echo.                                                           >> %logs%
 echo ====================== :CHKDSK ======================       >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :chkdsk label                           >> %logs%
-CHKDSK /f /r
-echo %date% %time% : Executed CHKDSK /f /r                         >> %logs%
+call :L "%cStep%" "CHKDSK - online integrity scan (SSD-safe, no reboot)..."
+chkdsk %SystemDrive% /scan
+>>%logs% echo %date% %time% : CHKDSK /scan exit=%errorlevel%
+echo %date% %time% : Executed chkdsk /scan                         >> %logs%
 if /i %autoclean% == 2 goto endready
+timeout /t 5
+goto endready
+
+
+:chkdsk_full
+echo.                                                           >> %logs%
+echo ====================== :CHKDSK_FULL ====================== >> %logs%
+echo %date% %time% : Entered :chkdsk_full label                    >> %logs%
+call :L "%cWarn%" "CHKDSK /f /r - full repair, locks the volume and schedules a reboot..."
+CHKDSK /f /r
+>>%logs% echo %date% %time% : CHKDSK /f /r exit=%errorlevel%
+echo %date% %time% : Executed CHKDSK /f /r                         >> %logs%
 timeout /t 5
 
 
@@ -703,6 +947,27 @@ echo ====================== :MSHUTDOWNREBOOT ================== >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :mshutdownreboot label                  >> %logs%
 cls
+:: --- Disk space freed report (before/after) ---
+color 0F
+call :get_free_mb "%SystemDrive%"
+set "FREE_AFTER=%FREE_MB%"
+if not defined FREE_BEFORE set "FREE_BEFORE=0"
+set /a FREED=FREE_AFTER-FREE_BEFORE
+set /a FREED_GB=FREED/1024
+set /a "FREED_DEC=(FREED*10/1024) %% 10"
+if %FREED_DEC% LSS 0 set "FREED_DEC=0"
+echo(
+echo(%cT%===============================================================%cR%
+echo(%cT%    OPTY v%current_version%  -  Disk space report  (drive %SystemDrive%)%cR%
+echo(%cT%===============================================================%cR%
+echo(    Free before : %cVal%%FREE_BEFORE%%cR% MB
+echo(    Free after  : %cVal%%FREE_AFTER%%cR% MB
+echo(    %cOK%Total freed : %FREED% MB   ^(%FREED_GB%.%FREED_DEC% GB^)%cR%
+echo(%cT%===============================================================%cR%
+echo(
+>>%logs% echo %date% %time% : DISK REPORT %SystemDrive% before=%FREE_BEFORE%MB after=%FREE_AFTER%MB freed=%FREED%MB approx=%FREED_GB%GB
+timeout /t 6 /nobreak >nul
+
 if /i %autoshutdownreboot% == 0 goto skipshutdownreboot
 if /i %autoshutdownreboot% == 1 goto shutdown
 if /i %autoshutdownreboot% == 2 goto reboot
@@ -715,6 +980,7 @@ echo ====================== :MSHUTDOWNREBOOTFIX ================   >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :mshutdownrebootfix label               >> %logs%
 echo Do you want to restart/stop the computer?
+set "choice="
 set /p choice= R (Reboot) - S (Stop) - 0 (No)
 echo %date% %time% : Opti-mshutdownrebootfix "%choice%"                   >> %logs%
 if /i "%choice%"=="R" goto reboot
@@ -789,6 +1055,7 @@ echo.
 echo   0. Menu                                                         
 echo.                                                  
 echo.                                                  
+set "choice="
 set /p choice= Enter action:
 echo %date% %time% : ReEnable.bat-mreenable "%choice%"                     >> %logs%
 if "%choice%"=="1" goto office_update
@@ -873,7 +1140,11 @@ echo      Choose your desired profile:
 echo.                                                  
 echo.                                                  
 echo   1. Mouse and power only                                          
-echo   10. Mouse and power only-                                        
+echo   10. Mouse and power only-
+echo   2. Gaming / Performance tweaks
+echo   3. Debloat 2026 (Recall / Copilot / sponsored apps / Widgets)
+echo   4. Re-assert good Windows defaults (Firewall / Defender / UAC / system)
+echo   20. Restore ALL profile defaults (gaming + debloat + services)                                        
 echo.                                                  
 echo.                                                  
 echo.                                                  
@@ -893,10 +1164,15 @@ echo.
 echo   0. Menu                                                         
 echo.                                                  
 echo.                                                  
+set "choice="
 set /p choice= Enter action:
 echo %date% %time% : RegProfil.bat-mregprofil "%choice%"              >> %logs%
 if "%choice%"=="1" goto map_only
 if "%choice%"=="10" goto map_only-
+if "%choice%"=="2" goto gaming_perf
+if "%choice%"=="3" goto debloat2026
+if "%choice%"=="4" goto reassert_defaults
+if "%choice%"=="20" goto gaming_restore
 if "%choice%"=="0" goto menu
 color 0C
 echo This is not a valid action                                      
@@ -904,16 +1180,250 @@ echo %date% %time% : Invalid option in :mregprofil                     >> %logs%
 timeout /t 5
 goto mregprofil
 
+
+:gaming_perf
+echo.                                                           >> %logs%
+echo ====================== :GAMING_PERF ====================== >> %logs%
+echo.                                                           >> %logs%
+echo %date% %time% : Entered :gaming_perf label                   >> %logs%
+color FC
+cls
+call :L "%cStep%" "Applying Gaming / Performance tweaks (registry, power, network)..."
+
+call :L "%cInfo%" "Game priority (MMCSS) + foreground boost"
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" /v "SystemResponsiveness" /t REG_DWORD /d 10 /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" /v "GPU Priority" /t REG_DWORD /d 8 /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" /v "Priority" /t REG_DWORD /d 6 /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" /v "Scheduling Category" /t REG_SZ /d "High" /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" /v "SFIO Priority" /t REG_SZ /d "High" /f >nul
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\PriorityControl" /v "Win32PrioritySeparation" /t REG_DWORD /d 38 /f >nul
+
+call :L "%cInfo%" "Game Mode ON + Hardware GPU scheduling (HAGS - reboot needed)"
+reg add "HKCU\Software\Microsoft\GameBar" /v "AutoGameModeEnabled" /t REG_DWORD /d 1 /f >nul
+reg add "HKCU\Software\Microsoft\GameBar" /v "AllowAutoGameMode" /t REG_DWORD /d 1 /f >nul
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" /v "HwSchMode" /t REG_DWORD /d 2 /f >nul
+
+call :L "%cInfo%" "Disabling CPU power throttling"
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" /v "PowerThrottlingOff" /t REG_DWORD /d 1 /f >nul
+
+call :L "%cInfo%" "Network latency: throttling off + Nagle off on all interfaces"
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" /v "NetworkThrottlingIndex" /t REG_DWORD /d 4294967295 /f >nul
+for /f "delims=" %%K in ('reg query "HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces" 2^>nul ^| findstr /b /i "HKEY"') do (
+    reg add "%%K" /v "TcpAckFrequency" /t REG_DWORD /d 1 /f >nul 2>&1
+    reg add "%%K" /v "TCPNoDelay" /t REG_DWORD /d 1 /f >nul 2>&1
+)
+
+call :L "%cInfo%" "Re-asserting good defaults: SSD TRIM on + system-managed pagefile (8.3 names off)"
+fsutil behavior set disabledeletenotify 0 >nul
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management" /v "AutomaticManagedPagefile" /t REG_DWORD /d 1 /f >nul
+fsutil behavior set disable8dot3 1 >nul
+
+call :L "%cInfo%" "Faster startup apps at login"
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize" /v "StartupDelayInMSec" /t REG_DWORD /d 0 /f >nul
+
+call :L "%cInfo%" "USB selective suspend off (active power plan)"
+powercfg /setacvalueindex SCHEME_CURRENT 2a737441-1930-4402-8d77-b2bebba308a3 48e6b7a6-50f5-4782-a5d4-53bb8f07e226 0 >nul
+powercfg /setdcvalueindex SCHEME_CURRENT 2a737441-1930-4402-8d77-b2bebba308a3 48e6b7a6-50f5-4782-a5d4-53bb8f07e226 0 >nul
+powercfg /setactive SCHEME_CURRENT >nul
+
+call :L "%cInfo%" "Background apps + telemetry off"
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" /v "GlobalUserDisabled" /t REG_DWORD /d 1 /f >nul
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\AppPrivacy" /v "LetAppsRunInBackground" /t REG_DWORD /d 2 /f >nul
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection" /v "AllowTelemetry" /t REG_DWORD /d 0 /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" /v "AllowTelemetry" /t REG_DWORD /d 0 /f >nul
+
+call :L "%cInfo%" "Disabling MPO (Multi-Plane Overlay) - fixes flicker/stutter, incl. 24H2+ keys"
+reg add "HKLM\SOFTWARE\Microsoft\Windows\Dwm" /v "OverlayTestMode" /t REG_DWORD /d 5 /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows\Dwm" /v "OverlayMinFPS" /t REG_DWORD /d 0 /f >nul
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" /v "DisableOverlays" /t REG_DWORD /d 1 /f >nul
+
+call :L "%cInfo%" "Disabling telemetry scheduled tasks (Appraiser / CEIP / DmClient)"
+schtasks /Change /TN "\Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser" /Disable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Application Experience\ProgramDataUpdater" /Disable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Application Experience\PcaPatchDbTask" /Disable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Application Experience\StartupAppTask" /Disable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Customer Experience Improvement Program\Consolidator" /Disable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Customer Experience Improvement Program\UsbCeip" /Disable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Feedback\Siuf\DmClient" /Disable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Feedback\Siuf\DmClientOnScenarioDownload" /Disable >nul 2>&1
+
+call :L "%cInfo%" "Disabling VBS / Memory Integrity HVCI for gaming - security tradeoff"
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity" /v "Enabled" /t REG_DWORD /d 0 /f >nul
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard" /v "EnableVirtualizationBasedSecurity" /t REG_DWORD /d 0 /f >nul
+
+call :L "%cOK%" "Gaming / Performance tweaks applied - a reboot is recommended (HAGS + Memory Integrity)."
+pause
+goto menu
+
+:gaming_restore
+echo.                                                           >> %logs%
+echo ====================== :GAMING_RESTORE =================== >> %logs%
+echo %date% %time% : Entered :gaming_restore label                 >> %logs%
+color FC
+cls
+call :L "%cStep%" "Restoring Windows defaults for the Gaming / Performance tweaks..."
+
+call :L "%cInfo%" "Resetting game priority (MMCSS) + foreground boost to defaults"
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" /v "SystemResponsiveness" /t REG_DWORD /d 20 /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" /v "GPU Priority" /t REG_DWORD /d 8 /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" /v "Priority" /t REG_DWORD /d 2 /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" /v "Scheduling Category" /t REG_SZ /d "High" /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" /v "SFIO Priority" /t REG_SZ /d "High" /f >nul
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\PriorityControl" /v "Win32PrioritySeparation" /t REG_DWORD /d 2 /f >nul
+
+call :L "%cInfo%" "Re-enabling CPU power throttling (default)"
+reg delete "HKLM\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" /v "PowerThrottlingOff" /f >nul 2>&1
+
+call :L "%cInfo%" "Restoring network defaults (throttling index + Nagle)"
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" /v "NetworkThrottlingIndex" /t REG_DWORD /d 10 /f >nul
+for /f "delims=" %%K in ('reg query "HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces" 2^>nul ^| findstr /b /i "HKEY"') do (
+    reg delete "%%K" /v "TcpAckFrequency" /f >nul 2>&1
+    reg delete "%%K" /v "TCPNoDelay" /f >nul 2>&1
+)
+
+call :L "%cInfo%" "Restoring 8.3 short names (default)"
+fsutil behavior set disable8dot3 2 >nul
+
+call :L "%cInfo%" "Restoring login startup delay (default)"
+reg delete "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize" /v "StartupDelayInMSec" /f >nul 2>&1
+
+call :L "%cInfo%" "Re-enabling USB selective suspend (default)"
+powercfg /setacvalueindex SCHEME_CURRENT 2a737441-1930-4402-8d77-b2bebba308a3 48e6b7a6-50f5-4782-a5d4-53bb8f07e226 1 >nul
+powercfg /setdcvalueindex SCHEME_CURRENT 2a737441-1930-4402-8d77-b2bebba308a3 48e6b7a6-50f5-4782-a5d4-53bb8f07e226 1 >nul
+powercfg /setactive SCHEME_CURRENT >nul
+
+call :L "%cInfo%" "Re-enabling background apps + telemetry (default)"
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" /v "GlobalUserDisabled" /t REG_DWORD /d 0 /f >nul
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows\AppPrivacy" /v "LetAppsRunInBackground" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection" /v "AllowTelemetry" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" /v "AllowTelemetry" /f >nul 2>&1
+
+call :L "%cInfo%" "Restoring MPO (Multi-Plane Overlay) to default"
+reg delete "HKLM\SOFTWARE\Microsoft\Windows\Dwm" /v "OverlayTestMode" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Microsoft\Windows\Dwm" /v "OverlayMinFPS" /f >nul 2>&1
+reg delete "HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" /v "DisableOverlays" /f >nul 2>&1
+
+call :L "%cInfo%" "Re-enabling telemetry scheduled tasks"
+schtasks /Change /TN "\Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser" /Enable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Application Experience\ProgramDataUpdater" /Enable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Application Experience\PcaPatchDbTask" /Enable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Application Experience\StartupAppTask" /Enable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Customer Experience Improvement Program\Consolidator" /Enable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Customer Experience Improvement Program\UsbCeip" /Enable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Feedback\Siuf\DmClient" /Enable >nul 2>&1
+schtasks /Change /TN "\Microsoft\Windows\Feedback\Siuf\DmClientOnScenarioDownload" /Enable >nul 2>&1
+
+call :L "%cInfo%" "Restoring Recall / Copilot / Consumer Features / Widgets"
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsAI" /v "DisableAIDataAnalysis" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsAI" /v "AllowRecallEnablement" /f >nul 2>&1
+reg delete "HKCU\Software\Policies\Microsoft\Windows\WindowsAI" /v "DisableAIDataAnalysis" /f >nul 2>&1
+sc config WSAIFabricSvc start= demand >nul 2>&1
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsCopilot" /v "TurnOffWindowsCopilot" /f >nul 2>&1
+reg delete "HKCU\Software\Policies\Microsoft\Windows\WindowsCopilot" /v "TurnOffWindowsCopilot" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsConsumerFeatures" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Dsh" /v "AllowNewsAndInterests" /f >nul 2>&1
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarDa" /t REG_DWORD /d 1 /f >nul
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowTaskViewButton" /t REG_DWORD /d 1 /f >nul
+
+call :L "%cInfo%" "Re-enabling VBS / Memory Integrity HVCI"
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity" /v "Enabled" /t REG_DWORD /d 1 /f >nul
+reg delete "HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard" /v "EnableVirtualizationBasedSecurity" /f >nul 2>&1
+
+call :L "%cInfo%" "Restoring services + GameDVR + hibernation to Windows defaults (map_only undo)"
+sc config SysMain start= auto >nul & sc start SysMain >nul 2>&1
+sc config WSearch start= delayed-auto >nul & sc start WSearch >nul 2>&1
+sc config Spooler start= auto >nul & sc start Spooler >nul 2>&1
+sc config DPS start= auto >nul & sc start DPS >nul 2>&1
+sc config WerSvc start= demand >nul
+sc config TabletInputService start= demand >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\DriverSearching" /v "SearchOrderConfig" /t REG_DWORD /d 1 /f >nul
+reg add "HKCU\System\GameConfigStore" /v "GameDVR_Enabled" /t REG_DWORD /d 1 /f >nul
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\GameDVR" /v "AppCaptureEnabled" /t REG_DWORD /d 1 /f >nul
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows\GameDVR" /v "AllowGameDVR" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Microsoft\PolicyManager\default\ApplicationManagement\AllowGameDVR" /v "value" /f >nul 2>&1
+powercfg /h on >nul
+
+call :L "%cOK%" "All profile defaults restored (gaming + debloat + services). Game Mode/HAGS left as-is."
+pause
+goto menu
+
+
+:debloat2026
+echo.                                                           >> %logs%
+echo ====================== :DEBLOAT2026 ====================== >> %logs%
+echo %date% %time% : Entered :debloat2026 label                   >> %logs%
+color FC
+cls
+call :L "%cStep%" "Debloat 2026 - disabling Recall, Copilot, sponsored apps and Widgets..."
+
+call :L "%cInfo%" "Disabling Windows Recall (AI snapshots) - 24H2+"
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsAI" /v "DisableAIDataAnalysis" /t REG_DWORD /d 1 /f >nul
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsAI" /v "AllowRecallEnablement" /t REG_DWORD /d 0 /f >nul
+reg add "HKCU\Software\Policies\Microsoft\Windows\WindowsAI" /v "DisableAIDataAnalysis" /t REG_DWORD /d 1 /f >nul
+sc stop WSAIFabricSvc >nul 2>&1
+sc config WSAIFabricSvc start= disabled >nul 2>&1
+
+call :L "%cInfo%" "Disabling Windows Copilot"
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsCopilot" /v "TurnOffWindowsCopilot" /t REG_DWORD /d 1 /f >nul
+reg add "HKCU\Software\Policies\Microsoft\Windows\WindowsCopilot" /v "TurnOffWindowsCopilot" /t REG_DWORD /d 1 /f >nul
+
+call :L "%cInfo%" "Blocking sponsored apps (Consumer Features)"
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsConsumerFeatures" /t REG_DWORD /d 1 /f >nul
+
+call :L "%cInfo%" "Disabling Widgets and Task View button"
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Dsh" /v "AllowNewsAndInterests" /t REG_DWORD /d 0 /f >nul
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarDa" /t REG_DWORD /d 0 /f >nul
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowTaskViewButton" /t REG_DWORD /d 0 /f >nul
+
+call :L "%cOK%" "Debloat 2026 applied. Sign out or reboot for all changes to take effect."
+pause
+goto menu
+
+
+:reassert_defaults
+echo.                                                           >> %logs%
+echo ====================== :REASSERT_DEFAULTS ================= >> %logs%
+echo %date% %time% : Entered :reassert_defaults label             >> %logs%
+color FC
+cls
+call :L "%cStep%" "Re-asserting Windows GOOD DEFAULTS (safety net vs prior bad tweaks)..."
+
+call :L "%cInfo%" "Windows Firewall ON (all profiles)"
+netsh advfirewall set allprofiles state on >nul
+
+call :L "%cInfo%" "Microsoft Defender real-time ON (removing disable overrides)"
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender" /v "DisableAntiSpyware" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender" /v "DisableAntiVirus" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" /v "DisableRealtimeMonitoring" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" /v "DisableBehaviorMonitoring" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" /v "DisableOnAccessProtection" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" /v "DisableScanOnRealtimeEnable" /f >nul 2>&1
+
+call :L "%cInfo%" "UAC ON (EnableLUA=1, secure prompt) - reboot needed if it was off"
+reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v "EnableLUA" /t REG_DWORD /d 1 /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v "ConsentPromptBehaviorAdmin" /t REG_DWORD /d 5 /f >nul
+
+call :L "%cInfo%" "System perf defaults: TRIM on, SysMain/Prefetch on, system-managed pagefile"
+fsutil behavior set disabledeletenotify 0 >nul
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" /v "EnablePrefetcher" /t REG_DWORD /d 00000003 /f >nul
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" /v "EnableSuperfetch" /t REG_DWORD /d 00000003 /f >nul
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management" /v "AutomaticManagedPagefile" /t REG_DWORD /d 1 /f >nul
+sc config SysMain start= auto >nul & sc start SysMain >nul 2>&1
+
+call :L "%cOK%" "Good defaults re-asserted. Reboot recommended if UAC was previously off."
+pause
+goto menu
+
+
 :map_only
 echo.                                                           >> %logs%
 echo ====================== :MAP_ONLY ======================       >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :map_only label                         >> %logs%
 cls
-reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" /v "EnablePrefetcher" /t REG_DWORD /d 00000000 /f
-echo %date% %time% : Set EnablePrefetcher=0                           >> %logs%
-reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" /v "EnableSuperfetch" /t REG_DWORD /d 00000000 /f
-echo %date% %time% : Set EnableSuperfetch=0                            >> %logs%
+echo %date% %time% : Re-asserting SysMain/Prefetch good defaults (2026 SSD best practice)   >> %logs%
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" /v "EnablePrefetcher" /t REG_DWORD /d 00000003 /f
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" /v "EnableSuperfetch" /t REG_DWORD /d 00000003 /f
 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\DriverSearching" /v "SearchOrderConfig" /t REG_DWORD /d 00000000 /f
 echo %date% %time% : Set SearchOrderConfig=0                            >> %logs%
 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PolicyManager\default\ApplicationManagement\AllowGameDVR" /v "value" /t REG_SZ /d "00000000" /f
@@ -934,10 +1444,11 @@ echo.                                                           >> %logs%
 echo ====================== :REGSC_MAP_ONLY ==================== >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :regsc_map_only label                   >> %logs%
+sc config SysMain start= auto
+echo %date% %time% : Re-asserted SysMain start= auto (good default)        >> %logs%
+sc start SysMain >nul 2>&1
 sc stop WSearch
 echo %date% %time% : Stopped service: WSearch                           >> %logs%
-sc stop SysMain
-echo %date% %time% : Stopped service: SysMain                            >> %logs%
 sc stop WerSvc
 echo %date% %time% : Stopped service: WerSvc                              >> %logs%
 sc stop Spooler
@@ -948,8 +1459,6 @@ sc stop TabletInputService
 echo %date% %time% : Stopped service: TabletInputService                 >> %logs%
 sc config "WSearch" start= demand
 echo %date% %time% : Configured WSearch start= demand                      >> %logs%
-sc config "SysMain" start= demand
-echo %date% %time% : Configured SysMain start= demand                       >> %logs%
 sc config "WerSvc" start= demand
 echo %date% %time% : Configured WerSvc start= demand                         >> %logs%
 sc config "Spooler" start= demand
@@ -968,10 +1477,9 @@ echo ====================== :MAP_ONLY- ======================      >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :map_only- label                         >> %logs%
 cls
-reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" /v "EnablePrefetcher" /t REG_DWORD /d 00000000 /f
-echo %date% %time% : (map_only-) Set EnablePrefetcher=0                >> %logs%
-reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" /v "EnableSuperfetch" /t REG_DWORD /d 00000000 /f
-echo %date% %time% : (map_only-) Set EnableSuperfetch=0               >> %logs%
+echo %date% %time% : (map_only-) Re-asserting SysMain/Prefetch good defaults    >> %logs%
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" /v "EnablePrefetcher" /t REG_DWORD /d 00000003 /f
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" /v "EnableSuperfetch" /t REG_DWORD /d 00000003 /f
 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\DriverSearching" /v "SearchOrderConfig" /t REG_DWORD /d 00000000 /f
 echo %date% %time% : (map_only-) Set SearchOrderConfig=0              >> %logs%
 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PolicyManager\default\ApplicationManagement\AllowGameDVR" /v "value" /t REG_SZ /d "00000000" /f
@@ -1006,7 +1514,10 @@ color FC
 cls
 echo.                                                  
 echo  WELCOME to OPTY by @YannD-Deltagon                         
-echo    Do you want to create the "ULTIMATE POWER" power plan?          
+echo    Do you want to create the "ULTIMATE POWER" power plan?
+echo.
+echo   1. Yes - create the ULTIMATE POWER power plan
+echo   2. No  - skip to mouse optimization          
 echo.                                                  
 echo.                                                  
 echo.                                                  
@@ -1031,6 +1542,7 @@ echo.
 echo   0. Menu                                                        
 echo.                                                  
 echo.                                                  
+set "choice="
 set /p choice= Enter action:
 echo %date% %time% : RegProfil.bat-mregpowercfg "%choice%"           >> %logs%
 if "%choice%"=="1" goto powercfg
@@ -1089,6 +1601,7 @@ echo.
 echo   0. Menu                                                         
 echo.                                                  
 echo.                                                  
+set "choice="
 set /p choice= Enter action:
 echo %date% %time% : RegProfil.bat-mregmouse "%choice%"             >> %logs%
 if "%choice%"=="1" goto mouseantilag
@@ -1106,27 +1619,16 @@ echo ====================== :MOUSEANTILAG ===================    >> %logs%
 echo.                                                           >> %logs%
 echo %date% %time% : Entered :mouseantilag label                     >> %logs%
 reg add "HKEY_CURRENT_USER\Control Panel\Mouse" /v "MouseSensitivity" /t REG_SZ /d "10" /f
-echo %date% %time% : Set MouseSensitivity=10                         >> %logs%
-reg add "HKEY_CURRENT_USER\Control Panel\Mouse" /v "SmoothMouseXCurve" /t REG_BINARY /d "0000000000CCCCC0809919406626003333" /f
-echo %date% %time% : Set SmoothMouseXCurve                           >> %logs%
-reg add "HKEY_CURRENT_USER\Control Panel\Mouse" /v "SmoothMouseYCurve" /t REG_BINARY /d "0000000000003800000070000000A8000000E000" /f
-echo %date% %time% : Set SmoothMouseYCurve                           >> %logs%
+echo %date% %time% : Set MouseSensitivity=10 (neutral pointer speed)  >> %logs%
+reg add "HKEY_CURRENT_USER\Control Panel\Mouse" /v "MouseSpeed" /t REG_SZ /d "0" /f
+echo %date% %time% : Set MouseSpeed=0 (Enhance pointer precision OFF) >> %logs%
+reg add "HKEY_CURRENT_USER\Control Panel\Mouse" /v "MouseThreshold1" /t REG_SZ /d "0" /f
+echo %date% %time% : Set MouseThreshold1=0                            >> %logs%
+reg add "HKEY_CURRENT_USER\Control Panel\Mouse" /v "MouseThreshold2" /t REG_SZ /d "0" /f
+echo %date% %time% : Set MouseThreshold2=0                            >> %logs%
 pause
 goto menu
 
-
-:nshutdown
-echo.                                                           >> %logs%
-echo ====================== :NSHUTDOWN =====================     >> %logs%
-echo.                                                           >> %logs%
-echo %date% %time% : Entered :nshutdown label                         >> %logs%
-echo.                                                  
-shutdown /a                                                     
-echo.                                                  
-echo The computer will not restart.                                  
-echo.                                                  
-timeout /t 10
-goto menu
 
 
 :Clean_Opty_Curl
@@ -1159,3 +1661,83 @@ echo.
 echo.                                                  
 timeout /t 15
 exit
+
+:: ============================================================
+:: ====================  HELPER SUBROUTINES  ==================
+:: ============================================================
+
+:sysinfo
+:: Comprehensive session header: colored console + full log
+cls
+color 0B
+set "OSVER="
+for /f "tokens=*" %%v in ('ver') do set "OSVER=%%v"
+echo(%cT%================  OPTY v%current_version%  -  SESSION  ================%cR%
+echo(    Date/time : %cVal%%date% %time%%cR%
+echo(    User      : %cVal%%USERNAME%%cR%   Machine : %cVal%%COMPUTERNAME%%cR%
+echo(    OS        : %cVal%%OSVER%%cR%
+echo(    CPU       : %cVal%%NUMBER_OF_PROCESSORS% threads%cR%   Arch : %cVal%%PROCESSOR_ARCHITECTURE%%cR%
+echo(    Log file  : %cInfo%%logs%%cR%
+echo(%cT%---------------------------------------------------------------%cR%
+echo(    Free space per drive:
+>>%logs% echo.
+>>%logs% echo ====================== :SYSINFO ======================
+>>%logs% echo %date% %time% : OPTY v%current_version% session start
+>>%logs% echo %date% %time% : User=%USERNAME% Machine=%COMPUTERNAME%
+>>%logs% echo %date% %time% : OS=%OSVER%
+>>%logs% echo %date% %time% : CPU=%NUMBER_OF_PROCESSORS% threads Arch=%PROCESSOR_ARCHITECTURE%
+call :show_drive C
+call :show_drive D
+call :show_drive E
+call :show_drive F
+echo(%cT%===============================================================%cR%
+timeout /t 4 /nobreak >nul
+goto :eof
+
+:show_drive
+:: %1 = drive letter (C, D...) ; prints + logs free MB if the drive exists
+if not exist "%~1:\" goto :eof
+call :get_free_mb "%~1:"
+echo(      %cVal%%~1:%cR%  free = %cOK%%FREE_MB%%cR% MB
+>>%logs% echo %date% %time% : Drive %~1: free=%FREE_MB% MB
+goto :eof
+
+:get_free_mb
+:: %1 = drive like C:  ->  sets FREE_MB (decimal MB, overflow-safe)
+set "FREE_MB=0"
+set "FREE_RAW="
+for /f "tokens=2 delims=:" %%a in ('fsutil volume diskfree %~1 2^>nul') do if not defined FREE_RAW set "FREE_RAW=%%a"
+if not defined FREE_RAW goto :eof
+for /f "tokens=1" %%b in ("%FREE_RAW%") do set "FREE_BYTES=%%b"
+if not defined FREE_BYTES goto :eof
+set "FREE_BYTES=%FREE_BYTES:,=%"
+set "FREE_BYTES=%FREE_BYTES: =%"
+set "FREE_MB=%FREE_BYTES:~0,-6%"
+if not defined FREE_MB set "FREE_MB=0"
+if "%FREE_MB%"=="" set "FREE_MB=0"
+goto :eof
+
+:L
+:: %~1 = ANSI color, %~2 = message  ->  colored console line + timestamped log
+echo(%~1%~2%cR%
+>>%logs% echo %date% %time% : %~2
+goto :eof
+
+:restore_point
+:: Create ONE system restore point per session, before any destructive change.
+:: Uses powershell.exe only here (no native CMD equivalent since WMIC is deprecated).
+if defined RP_DONE goto :eof
+set "RP_DONE=1"
+echo.                                                           >> %logs%
+echo ====================== :RESTORE_POINT ==================== >> %logs%
+echo %date% %time% : Creating system restore point               >> %logs%
+call :L "%cStep%" "Creating a System Restore Point - safety net before changes..."
+powershell -NoProfile -Command "Enable-ComputerRestore -Drive '%SystemDrive%\'" >nul 2>&1
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SystemRestore" /v "SystemRestorePointCreationFrequency" /t REG_DWORD /d 0 /f >nul 2>&1
+powershell -NoProfile -Command "Checkpoint-Computer -Description 'OPTY v%current_version% - before optimization' -RestorePointType 'MODIFY_SETTINGS'" >nul 2>&1
+if errorlevel 1 (
+    call :L "%cWarn%" "Restore point not created - System Protection may be off, continuing"
+) else (
+    call :L "%cOK%" "Restore point created"
+)
+goto :eof

--- a/README.md
+++ b/README.md
@@ -1,35 +1,125 @@
-## ⚡ QUICK START
+# ⚡ OPTY — Windows Optimizer & Cleaner
 
-1. Download [`OPTY.bat`](https://github.com/YannD-Deltagon/OPTY/blob/master/OPTY.bat)
-2. **Right-click > Run as administrator**
-3. Follow the on-screen instructions  
-✅ *Requires an active Internet connection*
-4. Use your numpad to navigate the menu — for a fast cleanup:  
-   👉 Press `1` + `Enter`, then `2r` + `Enter`  
-   *(Executes a Fast AutoClean + Reboot)*
+> A single, self-contained `.bat` with a clear colored menu to **clean**, **optimize** and **fix** Windows 10/11 — no install, no dependencies, pure CMD.
+>
+> 🧠 *Based on 7 years of IT experience and 2 years of laziness typing the same commands.*
 
+---
 
-## 📌 ABOUT <!-- omit in toc -->
+## 🚀 Quick Start
 
-A lightweight command menu to fix common Windows issues and optimize your system.
+1. Download [`OPTY.bat`](https://github.com/YannD-Deltagon/OPTY/blob/master/OPTY.bat) (no other file needed)
+2. **Right-click → Run as administrator**
+3. Follow the on-screen menu (use the numpad)
 
-> 🧠 **Based on 7 years of IT experience and 2 years of laziness typing the same commands**
+⚡ **Fast full cleanup + reboot:** press `1` `Enter`, then `3r` `Enter`
+*(Auto Full optimization, then reboot)*
 
-### 🎯 Features:
-- Clean temporary and junk files  
-- Smart defragmentation  
-- Performance tweaks and service optimizations  
-- Quick fixes for common bugs  
-- Built-in tools: DISM, SFC, netsh, and more...
+> ✅ An Internet connection is recommended (for the auto-update check) but **not required** — OPTY falls back to *local mode* if GitHub is unreachable.
 
-### 🖥️ Compatibility:
-- Windows **10** / **11**
-- Requires a **working Internet connection**
+---
 
+## 📌 What it does
 
-## 🛠️ HOW TO USE
+OPTY groups dozens of maintenance commands behind a readable menu, with **three levels of automation** so you stay in control.
 
-```bash
-1. Download OPTY.bat (no need for other files)
-2. Right-click > "Run as administrator"
-3. Use the menu to select desired actions
+### 🎯 Highlights (v04.0)
+- 🛟 **Automatic System Restore Point** before any change (the 2026 safety standard — System Protection is enabled on `C:` if needed)
+- 🧹 Deep cleanup: temp, caches (GPU/shader, browsers, apps), Windows Update cache, Delivery Optimization, dumps, logs, INetCache, thumbnails, `Windows.old`, Recycle Bin…
+- 🐳 **WSL / Docker disk compaction** — cleanly stops Docker Desktop & WSL, then shrinks the virtual disks (`docker_data.vhdx` + every distro `ext4.vhdx`) to reclaim space
+- 🛠️ Repair tools: `DISM` (with `AnalyzeComponentStore`), `SFC`, `CHKDSK` (online `/scan` by default, full `/f /r` on demand)
+- 🧰 Enables **Storage Sense** for ongoing automatic maintenance (the native 2026 complement to manual cleanup)
+- 🌐 Network: DNS flush, Winsock/IP reset (manual mode only) + **TCP good-default tuning** (autotuning normal / RSS on / heuristics off)
+- 💾 Storage: drive **optimization** (`defrag` / SSD TRIM)
+- ⚙️ Service & registry tweaks, **Ultimate Performance** power plan, mouse anti-lag
+- 🎮 Optional **Gaming / Performance profile**: game priority (MMCSS), Game Mode + HAGS, VBS/Memory Integrity off, power-throttling off, network latency (Nagle/throttling), SSD TRIM, USB-suspend off, background apps + telemetry off, **MPO off** (fixes game flicker/stutter, incl. 24H2+ keys), telemetry scheduled-tasks off
+- 🛡️ Optional **2026 debloat**: disable Windows **Recall** & **Copilot**, block sponsored apps (Consumer Features), disable **Widgets** & Task View — all reversible via **Restore ALL profile defaults**
+- 🔐 **Re-assert good Windows defaults** (safety net): turns **Firewall**, **Defender real-time** and **UAC** back ON, plus SSD TRIM / SysMain / Prefetch / system-managed pagefile — undoes damage left by shady "optimizers"
+- ♻️ Re-enable helpers (Office / Chrome / Windows Update behind corporate GPO)
+- 📊 **Disk-space-freed report** (before / after) at the end of every run
+- 🎨 **Live colored output** (ANSI/VT) + **complete timestamped logs** for every action
+
+### 🖥️ Compatibility
+- Windows **10** / **11** (x64)
+- Requires **administrator** rights (the script checks and exits otherwise)
+
+---
+
+## 🧭 Main menu
+
+| Key | Action |
+|-----|--------|
+| `1` | **Clean + Optimization** (opens the mode selector below) |
+| `2` | **Re-enable options** (Office / Chrome / Windows Update) |
+| `3` | **Register profile**: services, registry, power plan, mouse, **Gaming/Performance**, **Debloat 2026**, **Re-assert good defaults**, **Restore ALL defaults** |
+| `9` | Clean OPTY's own working files |
+| `0` | Exit |
+
+### 🔁 The 3 optimization modes (menu `1`)
+
+| Mode | Behaviour |
+|------|-----------|
+| **1 — Manual** | Asks before each step (DNS, DISM, SFC, Windows Update, Cleanmgr, delete, defrag, CHKDSK…). Full control. |
+| **2 — Auto (lite)** | Quick pass: Windows Update + cleanup, then the shutdown prompt. |
+| **3 — Auto (full)** | The works: services, DNS + TCP, DISM, SFC, Windows Update, **cleanup + WSL/Docker compaction**, defrag, then disk report. |
+
+**Suffixes** — add a letter after the mode number to chain a power action:
+- `3r` → Auto Full **+ reboot**
+- `3s` → Auto Full **+ shutdown**
+- `2r`, `2s` → same for Auto lite
+
+---
+
+## 📊 Reporting & logs
+
+- **Session header** at startup: OS build, machine, user, CPU, and **free space per drive**.
+- Every action is written to a timestamped log file next to the script: `logs_<date>_<time>.txt` (the 15 most recent are kept, older ones auto-pruned).
+- At the end of a run, a colored panel shows **free space before / after** and the amount **freed** (MB and ~GB).
+- Exit codes of the heavy operations (DISM, SFC, CHKDSK, DEFRAG) are logged.
+
+> 🎨 Colors use ANSI/VT sequences (best in **Windows Terminal**, the default on Windows 11). OPTY enables VT automatically.
+
+---
+
+## ⚙️ Configuration (edit before first run if needed)
+
+A few paths are defined as variables at the **top of the script** — change them to match your machine:
+
+```bat
+set "USERHOME=C:\Users\compt"
+set "WSL_DOCKER_VHDX=%USERHOME%\AppData\Local\Docker\wsl\disk\docker_data.vhdx"
+set "DOCKER_EXE=C:\Program Files\Docker\Docker\Docker Desktop.exe"
+```
+
+`USERHOME` is hard-coded (instead of `%USERPROFILE%`) so the right profile is used even when the script runs elevated under another admin account.
+
+---
+
+## ⚠️ Good to know (this is an aggressive optimizer)
+
+Some steps are intentionally thorough. In particular:
+
+- **Closes apps**: Docker Desktop, Edge/Chrome, and the Microsoft Store window are closed during cleanup.
+- **`Windows.old`** is deleted → you lose the ability to roll back to the previous Windows build.
+- **Restore points**: old shadow copies are trimmed (**the most recent one is kept**).
+- **`DISM /StartComponentCleanup /ResetBase`** → installed updates can no longer be uninstalled.
+- **`CHKDSK /f /r`** may schedule a scan on the next reboot.
+- WSL/Docker compaction stops Docker — it is **not** restarted automatically.
+
+When in doubt, run **Mode 1 (Manual)** first: it asks before each step and ends with the disk-space report.
+
+> 🛟 A **System Restore Point** is created automatically before any of the above runs (menu `1`/`2`/`3`), so you can roll back from *Settings → System → Recovery → Open System Restore*.
+
+---
+
+## 🔄 Self-update
+
+On launch OPTY copies itself to `C:\OPTY_by-YannD\` and checks GitHub for a newer release. Hidden menu input:
+- `.` → force the update check
+
+---
+
+## 🙏 Credits
+
+Made by **[@YannD-Deltagon](https://github.com/YannD-Deltagon)**.
+Use at your own risk — review the script before running it on a machine you care about.


### PR DESCRIPTION
Major rework of OPTY (02.4 -> 04.0), validated against 2026 Windows 11 standards. Pure CMD/.bat (one sanctioned powershell.exe call for the restore point only).

New features
- System Restore Point created before any change (menu 1/2/3)
- WSL/Docker vhdx compaction: clean Docker -quit + state polling, then diskpart compact vdisk (docker_data.vhdx + every distro ext4.vhdx)
- Live ANSI/VT colored output + complete timestamped logs + session header
- Disk-space-freed report (before/after, 32-bit-overflow-safe via fsutil)
- Expanded W11 cleanup (app/font caches, WER, CBS/Panther, thumbnails, INetCache, driver leftovers, Windows.old, restore-point trim) gated to Full mode for the destructive parts
- Storage Sense enabled; DISM AnalyzeComponentStore; CHKDSK /scan default (/f /r on demand); usoclient scaninstallwait
- Gaming/Performance profile: MMCSS, Game Mode, HAGS, MPO off (incl. 24H2+ keys), VBS/Memory Integrity off, power-throttling off, Nagle/throttling, USB-suspend off, telemetry scheduled-tasks off
- Debloat 2026: Recall, Copilot, Consumer Features, Widgets/Task View
- Re-assert good defaults (safety net): Firewall/Defender/UAC ON, TRIM, SysMain/Prefetch, system-managed pagefile
- Restore ALL profile defaults (gaming + debloat + services) round-trip

Reliability / 2026 corrections
- Fixed crash on hidden '-' input (goto to a non-existent label)
- Reset %choice% before every set /p (no stale-input re-execution)
- Robust log filename (sanitize %date% slashes)
- Keep SysMain/Prefetch enabled on SSD (2026 best practice) and stop clearing the Prefetch cache
- Win32PrioritySeparation = 38 (the real 0x26 gaming value)
- Proper mouse-acceleration disable (MouseSpeed/Threshold) instead of resolution-dependent curves
- Winsock/IP reset kept manual-only; ECN left at default

README rewritten and synchronized with v04.0.