### PR TITLE
Hotfix: CRLF (.gitattributes), locale-safe disk-free, MPO/HAGS opt-in

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Force Windows line endings for batch files so `curl`-downloaded copies stay
+# valid. CMD's call/goto :eof return uses byte offsets assuming 2-byte CRLF;
+# LF endings shift the return address and corrupt execution deep in the script.
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+
+# Keep the rest as-is / let Git decide
+*.md    text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# OPTY runtime artifacts
+logs_*.txt
+new_OPTY.bat

--- a/OPTY.bat
+++ b/OPTY.bat
@@ -1144,6 +1144,7 @@ echo   10. Mouse and power only-
 echo   2. Gaming / Performance tweaks
 echo   3. Debloat 2026 (Recall / Copilot / sponsored apps / Widgets)
 echo   4. Re-assert good Windows defaults (Firewall / Defender / UAC / system)
+echo   5. Display tweaks (MPO / HAGS) - test on/off, can flicker multi-monitor
 echo   20. Restore ALL profile defaults (gaming + debloat + services)                                        
 echo.                                                  
 echo.                                                  
@@ -1172,6 +1173,7 @@ if "%choice%"=="10" goto map_only-
 if "%choice%"=="2" goto gaming_perf
 if "%choice%"=="3" goto debloat2026
 if "%choice%"=="4" goto reassert_defaults
+if "%choice%"=="5" goto display_tweaks
 if "%choice%"=="20" goto gaming_restore
 if "%choice%"=="0" goto menu
 color 0C
@@ -1198,10 +1200,9 @@ reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProf
 reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" /v "SFIO Priority" /t REG_SZ /d "High" /f >nul
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\PriorityControl" /v "Win32PrioritySeparation" /t REG_DWORD /d 38 /f >nul
 
-call :L "%cInfo%" "Game Mode ON + Hardware GPU scheduling (HAGS - reboot needed)"
+call :L "%cInfo%" "Game Mode ON (HAGS and MPO moved to menu 3 -> 5: Display tweaks)"
 reg add "HKCU\Software\Microsoft\GameBar" /v "AutoGameModeEnabled" /t REG_DWORD /d 1 /f >nul
 reg add "HKCU\Software\Microsoft\GameBar" /v "AllowAutoGameMode" /t REG_DWORD /d 1 /f >nul
-reg add "HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" /v "HwSchMode" /t REG_DWORD /d 2 /f >nul
 
 call :L "%cInfo%" "Disabling CPU power throttling"
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" /v "PowerThrottlingOff" /t REG_DWORD /d 1 /f >nul
@@ -1232,11 +1233,6 @@ reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\AppPrivacy" /v "LetAppsRunInBa
 reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection" /v "AllowTelemetry" /t REG_DWORD /d 0 /f >nul
 reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" /v "AllowTelemetry" /t REG_DWORD /d 0 /f >nul
 
-call :L "%cInfo%" "Disabling MPO (Multi-Plane Overlay) - fixes flicker/stutter, incl. 24H2+ keys"
-reg add "HKLM\SOFTWARE\Microsoft\Windows\Dwm" /v "OverlayTestMode" /t REG_DWORD /d 5 /f >nul
-reg add "HKLM\SOFTWARE\Microsoft\Windows\Dwm" /v "OverlayMinFPS" /t REG_DWORD /d 0 /f >nul
-reg add "HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" /v "DisableOverlays" /t REG_DWORD /d 1 /f >nul
-
 call :L "%cInfo%" "Disabling telemetry scheduled tasks (Appraiser / CEIP / DmClient)"
 schtasks /Change /TN "\Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser" /Disable >nul 2>&1
 schtasks /Change /TN "\Microsoft\Windows\Application Experience\ProgramDataUpdater" /Disable >nul 2>&1
@@ -1251,7 +1247,7 @@ call :L "%cInfo%" "Disabling VBS / Memory Integrity HVCI for gaming - security t
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity" /v "Enabled" /t REG_DWORD /d 0 /f >nul
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard" /v "EnableVirtualizationBasedSecurity" /t REG_DWORD /d 0 /f >nul
 
-call :L "%cOK%" "Gaming / Performance tweaks applied - a reboot is recommended (HAGS + Memory Integrity)."
+call :L "%cOK%" "Gaming / Performance tweaks applied - a reboot is recommended (Memory Integrity)."
 pause
 goto menu
 
@@ -1413,6 +1409,74 @@ sc config SysMain start= auto >nul & sc start SysMain >nul 2>&1
 call :L "%cOK%" "Good defaults re-asserted. Reboot recommended if UAC was previously off."
 pause
 goto menu
+
+
+:display_tweaks
+echo.                                                           >> %logs%
+echo ====================== :DISPLAY_TWEAKS ================== >> %logs%
+echo %date% %time% : Entered :display_tweaks label              >> %logs%
+color FC
+cls
+echo.
+echo  WELCOME to OPTY by @YannD-Deltagon
+echo    Display tweaks - test individually, REBOOT after each.
+echo.
+echo    WARNING: these can FIX or CAUSE flicker/stutter, especially on
+echo    multi-monitor setups with mixed refresh rates or VRR (FreeSync/G-Sync).
+echo.
+echo   1. Disable MPO (Multi-Plane Overlay)
+echo   2. Re-enable MPO  (Windows default)
+echo.
+echo   3. Enable HAGS  (Hardware-accelerated GPU Scheduling)
+echo   4. Disable HAGS (Windows default)
+echo.
+echo   0. Back to menu
+echo.
+set "choice="
+set /p choice= Enter action:
+echo %date% %time% : display_tweaks "%choice%"                    >> %logs%
+if "%choice%"=="1" goto dt_mpo_off
+if "%choice%"=="2" goto dt_mpo_on
+if "%choice%"=="3" goto dt_hags_on
+if "%choice%"=="4" goto dt_hags_off
+if "%choice%"=="0" goto menu
+color 0C
+echo This is not a valid action
+echo %date% %time% : Invalid option in :display_tweaks            >> %logs%
+timeout /t 5
+goto display_tweaks
+
+:dt_mpo_off
+call :L "%cWarn%" "Disabling MPO - can FIX or CAUSE multi-monitor flicker. Reboot after."
+reg add "HKLM\SOFTWARE\Microsoft\Windows\Dwm" /v "OverlayTestMode" /t REG_DWORD /d 5 /f >nul
+reg add "HKLM\SOFTWARE\Microsoft\Windows\Dwm" /v "OverlayMinFPS" /t REG_DWORD /d 0 /f >nul
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" /v "DisableOverlays" /t REG_DWORD /d 1 /f >nul
+call :L "%cOK%" "MPO disabled. REBOOT required."
+pause
+goto display_tweaks
+
+:dt_mpo_on
+call :L "%cOK%" "Re-enabling MPO (Windows default) - fixes most multi-monitor flicker"
+reg delete "HKLM\SOFTWARE\Microsoft\Windows\Dwm" /v "OverlayTestMode" /f >nul 2>&1
+reg delete "HKLM\SOFTWARE\Microsoft\Windows\Dwm" /v "OverlayMinFPS" /f >nul 2>&1
+reg delete "HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" /v "DisableOverlays" /f >nul 2>&1
+call :L "%cOK%" "MPO re-enabled. REBOOT required."
+pause
+goto display_tweaks
+
+:dt_hags_on
+call :L "%cWarn%" "Enabling HAGS (HwSchMode=2). Reboot after."
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" /v "HwSchMode" /t REG_DWORD /d 2 /f >nul
+call :L "%cOK%" "HAGS enabled. REBOOT required."
+pause
+goto display_tweaks
+
+:dt_hags_off
+call :L "%cWarn%" "Disabling HAGS (HwSchMode=1, Windows default). Reboot after."
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" /v "HwSchMode" /t REG_DWORD /d 1 /f >nul
+call :L "%cOK%" "HAGS disabled. REBOOT required."
+pause
+goto display_tweaks
 
 
 :map_only
@@ -1703,16 +1767,14 @@ echo(      %cVal%%~1:%cR%  free = %cOK%%FREE_MB%%cR% MB
 goto :eof
 
 :get_free_mb
-:: %1 = drive like C:  ->  sets FREE_MB (decimal MB, overflow-safe)
+:: %1 = drive like C:  ->  sets FREE_MB (MB, locale- and overflow-safe via .NET)
+:: fsutil's number is locale-formatted (FR thousands separators 0xA0/0xFF break
+:: a pure-CMD parse and produce garbage like 499ÿ303ÿ9), so we read the raw byte
+:: count through .NET DriveInfo and convert to MB.
 set "FREE_MB=0"
-set "FREE_RAW="
-for /f "tokens=2 delims=:" %%a in ('fsutil volume diskfree %~1 2^>nul') do if not defined FREE_RAW set "FREE_RAW=%%a"
-if not defined FREE_RAW goto :eof
-for /f "tokens=1" %%b in ("%FREE_RAW%") do set "FREE_BYTES=%%b"
-if not defined FREE_BYTES goto :eof
-set "FREE_BYTES=%FREE_BYTES:,=%"
-set "FREE_BYTES=%FREE_BYTES: =%"
-set "FREE_MB=%FREE_BYTES:~0,-6%"
+powershell -NoProfile -Command "try{[math]::Floor([System.IO.DriveInfo]::new('%~1').AvailableFreeSpace/1MB)}catch{0}" > "%TEMP%\opty_free.txt" 2>nul
+set /p FREE_MB=<"%TEMP%\opty_free.txt"
+del /f /q "%TEMP%\opty_free.txt" >nul 2>&1
 if not defined FREE_MB set "FREE_MB=0"
 if "%FREE_MB%"=="" set "FREE_MB=0"
 goto :eof

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ OPTY groups dozens of maintenance commands behind a readable menu, with **three 
 - 🌐 Network: DNS flush, Winsock/IP reset (manual mode only) + **TCP good-default tuning** (autotuning normal / RSS on / heuristics off)
 - 💾 Storage: drive **optimization** (`defrag` / SSD TRIM)
 - ⚙️ Service & registry tweaks, **Ultimate Performance** power plan, mouse anti-lag
-- 🎮 Optional **Gaming / Performance profile**: game priority (MMCSS), Game Mode + HAGS, VBS/Memory Integrity off, power-throttling off, network latency (Nagle/throttling), SSD TRIM, USB-suspend off, background apps + telemetry off, **MPO off** (fixes game flicker/stutter, incl. 24H2+ keys), telemetry scheduled-tasks off
+- 🎮 Optional **Gaming / Performance profile**: game priority (MMCSS), Game Mode, VBS/Memory Integrity off, power-throttling off, network latency (Nagle/throttling), SSD TRIM, USB-suspend off, background apps + telemetry off, telemetry scheduled-tasks off
+- 🖥️ Separate **Display tweaks** menu (opt-in) to toggle **MPO** and **HAGS** on/off individually — these can *fix or cause* flicker/stutter, so they're kept out of the auto profile (⚠️ MPO-off is a known cause of **multi-monitor black flicker** on mixed-refresh / VRR setups)
 - 🛡️ Optional **2026 debloat**: disable Windows **Recall** & **Copilot**, block sponsored apps (Consumer Features), disable **Widgets** & Task View — all reversible via **Restore ALL profile defaults**
 - 🔐 **Re-assert good Windows defaults** (safety net): turns **Firewall**, **Defender real-time** and **UAC** back ON, plus SSD TRIM / SysMain / Prefetch / system-managed pagefile — undoes damage left by shady "optimizers"
 - ♻️ Re-enable helpers (Office / Chrome / Windows Update behind corporate GPO)
@@ -51,7 +52,7 @@ OPTY groups dozens of maintenance commands behind a readable menu, with **three 
 |-----|--------|
 | `1` | **Clean + Optimization** (opens the mode selector below) |
 | `2` | **Re-enable options** (Office / Chrome / Windows Update) |
-| `3` | **Register profile**: services, registry, power plan, mouse, **Gaming/Performance**, **Debloat 2026**, **Re-assert good defaults**, **Restore ALL defaults** |
+| `3` | **Register profile**: services, registry, power plan, mouse, **Gaming/Performance**, **Debloat 2026**, **Re-assert good defaults**, **Display tweaks (MPO/HAGS)**, **Restore ALL defaults** |
 | `9` | Clean OPTY's own working files |
 | `0` | Exit |
 


### PR DESCRIPTION
- Add .gitattributes (*.bat text eol=crlf) + renormalize: CMD's call/goto :eof return is byte-offset based and assumes CRLF; LF (from Git/curl auto-update) shifted the return into :gaming_restore/:debloat2026 and made :dism run the wrong code. This is the real fix for that corruption.
- get_free_mb: read free space via .NET DriveInfo instead of parsing fsutil's locale-formatted number (FR thousands separators 0xA0/0xFF broke the CMD parse -> garbage like 499ÿ303ÿ9 MB).
- Move MPO (OverlayTestMode/OverlayMinFPS/DisableOverlays) and HAGS (HwSchMode) OUT of the auto Gaming profile into a new opt-in "Display tweaks" menu (3 -> 5) with on/off for each + a multi-monitor warning. Disabling MPO is hardware-dependent and causes black-flicker on multi-monitor mixed-refresh/VRR setups. Game Mode stays in the profile.
- Add .gitignore (logs_*.txt, new_OPTY.bat).
- README updated.